### PR TITLE
Feat/choose screen size

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ export const App = () => {
 
   return (
     <SafeAreaProvider>
-      <ScreenSizer.Wrapper>
+      <ScreenSizer.Wrapper device={ScreenSizer.deviceSizes['iPhone SE 2016']}>
         {/* 👋 `ScreenSizer.Wrapper` must be inserted inside `SafeAreaProvider` but **around** any provider or component that uses safe area dimensions */}
         {/* The rest of your providers and your app */}
       </ScreenSizer.Wrapper>
@@ -52,6 +52,8 @@ export const App = () => {
 
 ## Usage
 
+- The `Wrapper` prop `device` is the device you want to emulate. You can find the list of available devices in `ScreenSizer.deviceSizes`. You can also pass a custom device size object.
+- `device` is optional. If you don't pass it, an `iPhone SE 2016` size will be used.
 - We recommend using a big screen (eg `iPhone 14 Pro Max`) as the "base device" to develop on.
 - Open the expo dev menu (cmd+d) and tap "Toggle Screen Sizer"
 - You're in screen sizer mode!

--- a/src/Wrapper.tsx
+++ b/src/Wrapper.tsx
@@ -12,10 +12,14 @@ import { deviceSizes } from './sizes';
 import { useStore } from './state';
 import type { ScreenDescription } from './types';
 
-const screenDescription: ScreenDescription = deviceSizes['iPhone SE 2016'];
+type WrapperMemoProps = PropsWithChildren<{
+  device?: ScreenDescription;
+}>;
 
-const WrapperMemo = ({ children }: PropsWithChildren) => {
+const WrapperMemo = ({ children, device }: WrapperMemoProps) => {
   const { isEnabled } = useStore();
+  const screenDescription: ScreenDescription =
+    device || deviceSizes['iPhone SE 2016'];
 
   const realInsets = useSafeAreaInsets();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,3 +11,5 @@ export const setup = (
 export const Wrapper = (
   __DEV__ ? WrapperInternal : IdentityComponent
 ) as typeof WrapperInternal;
+
+export { deviceSizes } from './sizes';


### PR DESCRIPTION
[Ticket: [v0.1] ETQDev, je peux choisir la taille de l’écran simulé](https://www.notion.so/m33/v0-1-ETQDev-je-peux-choisir-la-taille-de-l-cran-simul-66312e123dd74e23aff186cb468ac3d7?pvs=4)

## Description

- export default deviceSizes
- add ScreenDescription as a prop of wrapper