### PR TITLE
Make expo optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,18 +60,25 @@ so you can safely add them without adding `__DEV__` conditions yourself.
 
 ## Usage
 
-- The `Wrapper` prop `device` is the device you want to emulate. You can find
-  the list of available devices in `ScreenSizer.deviceSizes`. You can also
-  pass a custom device size object.
-- `device` is optional. If you don't pass it, an `iPhone SE 2016` size will be used.
 - We recommend using a big screen (eg `iPhone 14 Pro Max`) as the "base device"
   to develop on.
+- The `Wrapper` prop `device` (optional) is the device you want to emulate. You can find
+  the list of available devices in `ScreenSizer.deviceSizes`, or pass a custom size.
+  By default, the `iPhone SE 2016` size will be used.
 - To toggle the Screen Sizer:
+
   - Open the dev menu (<kbd>⌘ cmd</kbd> + <kbd>D</kbd> on iOS or
     <kbd>⌘ cmd</kbd> + <kbd>M</kbd> on Android)
     and tap `"📐 Toggle Screen Sizer"`
   - **OR** import the function `ScreenSizer.toggleIsEnabled()` in your code
     and link it to a button to activate the screen sizer!
+  - Compatibility of each feature by project type:
+
+    |                  | ReactNative Dev Menu | Expo Dev Menu | `toggle` function |
+    | ---------------- | :------------------: | :-----------: | :---------------: |
+    | Bare ReactNative |          ✅          |      ❌       |        ✅         |
+    | Expo Go          |          ❌          |      ❌       |        ✅         |
+    | Expo             |          ✅          |      ✅       |        ✅         |
 
 ## Making it work well
 

--- a/README.md
+++ b/README.md
@@ -16,10 +16,9 @@ Currently, screen-sizer will only work with expo projects.
 yarn add react-native-screen-sizer
 ```
 
-You'll need to have these dependencies installed:
+You'll need to have the `react-native-safe-area-context` dependency installed:
 
 ```
-npx expo install expo-dev-client
 npx expo install react-native-safe-area-context
 ```
 
@@ -55,8 +54,10 @@ export const App = () => {
 - The `Wrapper` prop `device` is the device you want to emulate. You can find the list of available devices in `ScreenSizer.deviceSizes`. You can also pass a custom device size object.
 - `device` is optional. If you don't pass it, an `iPhone SE 2016` size will be used.
 - We recommend using a big screen (eg `iPhone 14 Pro Max`) as the "base device" to develop on.
-- Open the expo dev menu (cmd+d) and tap "Toggle Screen Sizer"
-- You're in screen sizer mode!
+- To toggle the Screen Sizer:
+  - If you use expo, open the expo dev menu (<kbd>⌘ cmd</kbd> + <kbd>D</kbd>) and tap `"📐 Toggle Screen Sizer"` (you'll need to have `expo-dev-menu` installed in your project)
+  - **OR** if you don't use expo, open the react native dev menu (<kbd>⌘ cmd</kbd> + <kbd>D</kbd>) and tap `"📐 Toggle Screen Sizer"`
+  - **OR** import the function `ScreenSizer.toggleIsEnabled()` in your code and link it to a button to activate the screen sizer!
 
 ## Making it work well
 
@@ -101,11 +102,10 @@ You can setup these eslint rules to enforce some of the guidelines above:
 
 ### Current limitations
 
-- Only apps with the **expo dev menu** have access to the button to enable screen sizer mode for now
 - **Landscape mode** is not supported
 - On android, the **status bar** inset is applied as if the status bar is visible and translucent
 - **Keyboard insets** emulation is very experimental, don't trust it too much
-- If the "base device" is smaller than the "sized screen", behaviour is undefined
+- If the "base device" is smaller than the "sized screen", behavior is undefined
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -74,11 +74,11 @@ so you can safely add them without adding `__DEV__` conditions yourself.
     and link it to a button to activate the screen sizer!
   - Compatibility of each feature by project type:
 
-    |                  | ReactNative Dev Menu | Expo Dev Menu | `toggle` function |
-    | ---------------- | :------------------: | :-----------: | :---------------: |
-    | Bare ReactNative |          ✅          |      ❌       |        ✅         |
-    | Expo Go          |          ❌          |      ❌       |        ✅         |
-    | Expo             |          ✅          |      ✅       |        ✅         |
+    |                        | React Native Dev Menu | Expo Dev Menu | `toggle` function |
+    | ---------------------- | :-------------------: | :-----------: | :---------------: |
+    | Bare React Native      |          ✅           |      ❌       |        ✅         |
+    | Expo Go                |          ❌           |      ❌       |        ✅         |
+    | Expo Custom Dev Client |          ✅           |      ✅       |        ✅         |
 
 ## Making it work well
 

--- a/README.md
+++ b/README.md
@@ -10,17 +10,25 @@ Quickly check how your app looks on different screen sizes.
 
 ## Installation
 
-Currently, screen-sizer will only work with expo projects.
-
 ```sh
 yarn add react-native-screen-sizer
 ```
 
-You'll need to have the `react-native-safe-area-context` dependency installed:
+You'll also need to have these dependencies installed:
 
-```
-npx expo install react-native-safe-area-context
-```
+- if you use `expo go`:
+  ```bash
+  npx expo install react-native-safe-area-context
+  ```
+- if you use `expo` with a custom build:
+  ```bash
+  npx expo install react-native-safe-area-context expo-dev-client
+  ```
+- if you use a bare React Native project:
+  ```bash
+  yarn add react-native-safe-area-context
+  npx pod-install
+  ```
 
 Then, add it to `App.tsx`:
 
@@ -47,17 +55,23 @@ export const App = () => {
 };
 ```
 
-**NOTE**: The `Wrapper` and the setup function are no-ops in release builds, so you can safely add them without adding `__DEV__` conditions yourself.
+**NOTE**: The `Wrapper` and the setup function are no-ops in release builds,
+so you can safely add them without adding `__DEV__` conditions yourself.
 
 ## Usage
 
-- The `Wrapper` prop `device` is the device you want to emulate. You can find the list of available devices in `ScreenSizer.deviceSizes`. You can also pass a custom device size object.
+- The `Wrapper` prop `device` is the device you want to emulate. You can find
+  the list of available devices in `ScreenSizer.deviceSizes`. You can also
+  pass a custom device size object.
 - `device` is optional. If you don't pass it, an `iPhone SE 2016` size will be used.
-- We recommend using a big screen (eg `iPhone 14 Pro Max`) as the "base device" to develop on.
+- We recommend using a big screen (eg `iPhone 14 Pro Max`) as the "base device"
+  to develop on.
 - To toggle the Screen Sizer:
-  - If you use expo, open the expo dev menu (<kbd>⌘ cmd</kbd> + <kbd>D</kbd>) and tap `"📐 Toggle Screen Sizer"` (you'll need to have `expo-dev-menu` installed in your project)
-  - **OR** if you don't use expo, open the react native dev menu (<kbd>⌘ cmd</kbd> + <kbd>D</kbd>) and tap `"📐 Toggle Screen Sizer"`
-  - **OR** import the function `ScreenSizer.toggleIsEnabled()` in your code and link it to a button to activate the screen sizer!
+  - Open the dev menu (<kbd>⌘ cmd</kbd> + <kbd>D</kbd> on iOS or
+    <kbd>⌘ cmd</kbd> + <kbd>M</kbd> on Android)
+    and tap `"📐 Toggle Screen Sizer"`
+  - **OR** import the function `ScreenSizer.toggleIsEnabled()` in your code
+    and link it to a button to activate the screen sizer!
 
 ## Making it work well
 

--- a/example/package.json
+++ b/example/package.json
@@ -11,7 +11,6 @@
   "dependencies": {
     "expo": "~48.0.18",
     "expo-dev-client": "~2.2.1",
-    "expo-dev-menu": "^2.2.0",
     "expo-status-bar": "~1.4.4",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { StyleSheet, Text, View } from 'react-native';
+import { Button, StyleSheet, Text, View } from 'react-native';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import * as ScreenSizer from 'react-native-screen-sizer';
 
@@ -11,7 +11,11 @@ export default function App() {
     <SafeAreaProvider>
       <ScreenSizer.Wrapper>
         <View style={styles.container}>
-          <Text>Coucou!</Text>
+          <Text style={styles.title}>ScreenSizer Demo Application</Text>
+          <Button
+            onPress={() => ScreenSizer.toggleIsEnabled()}
+            title="Toggle Screen Sizer"
+          />
         </View>
       </ScreenSizer.Wrapper>
     </SafeAreaProvider>
@@ -23,5 +27,10 @@ const styles = StyleSheet.create({
     flex: 1,
     alignItems: 'center',
     justifyContent: 'center',
+  },
+  title: {
+    fontSize: 28,
+    textAlign: 'center',
+    marginBottom: 28,
   },
 });

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -4084,7 +4084,7 @@ expo-dev-menu-interface@1.1.1:
   resolved "https://registry.yarnpkg.com/expo-dev-menu-interface/-/expo-dev-menu-interface-1.1.1.tgz#8a0d979f62d9a192696f66a77f75d8fab79e604b"
   integrity sha512-doT+7WrSBnxCcTGZw9QIEZoL+43U4RywbG8XZwbhkcsFWGsh9scp0y/bv3ieFHxRtIdImxbxOoYh7fy1O6g28w==
 
-expo-dev-menu@2.2.0, expo-dev-menu@^2.2.0:
+expo-dev-menu@2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/expo-dev-menu/-/expo-dev-menu-2.2.0.tgz#849ec3601f1dc228ad2858e4a25614a72932a61c"
   integrity sha512-ImRUD7IVyLme7t3S+pNsOOgCBorkriVNo+ryEmkAjzRTKlpiklhoc1GEdQUU3qvO6e66gUguMbs4wnaP6o4NEw==

--- a/package.json
+++ b/package.json
@@ -81,10 +81,10 @@
   },
   "peerDependenciesMeta": {
     "expo": {
-      "optional": false
+      "optional": true
     },
     "expo-dev-menu": {
-      "optional": false
+      "optional": true
     }
   },
   "engines": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react';
 import { Wrapper as WrapperInternal } from './Wrapper';
 import { setup as setupInternal } from './setup';
+import { store } from './state';
 
 const IdentityComponent = ({ children }: { children: ReactNode }) => children;
 
@@ -11,5 +12,9 @@ export const setup = (
 export const Wrapper = (
   __DEV__ ? WrapperInternal : IdentityComponent
 ) as typeof WrapperInternal;
+
+export const toggleIsEnabled = __DEV__
+  ? () => store.toggleIsEnabled()
+  : () => {};
 
 export { deviceSizes } from './sizes';

--- a/src/integrations/expo-dev-menu.ts
+++ b/src/integrations/expo-dev-menu.ts
@@ -4,9 +4,15 @@ import { store } from '../state';
  * NOTE: this will override any other custom items, not good!
  */
 export const registerExpoDevMenuItem = async () => {
+  let ExpoDevMenu;
   try {
-    const ExpoDevMenu = await import('expo-dev-menu');
+    ExpoDevMenu = await import('expo-dev-menu');
+  } catch {
+    console.log('ScreenSizer: skipped registration of item in expo dev menu.');
+    return;
+  }
 
+  try {
     await ExpoDevMenu.registerDevMenuItems([
       {
         name: '📐 Toggle Screen Sizer',
@@ -14,6 +20,9 @@ export const registerExpoDevMenuItem = async () => {
       },
     ]);
   } catch (error) {
-    console.log('Error with expo-dev-menu', error);
+    console.warn(
+      'ScreenSizer: registration of item in expo dev menu failed',
+      error
+    );
   }
 };

--- a/src/integrations/expo-dev-menu.ts
+++ b/src/integrations/expo-dev-menu.ts
@@ -1,16 +1,19 @@
-import * as ExpoDevMenu from 'expo-dev-menu';
-import type { ExpoDevMenuItem } from 'expo-dev-menu/build/ExpoDevMenu.types';
-
 import { store } from '../state';
-
-export const devMenuItem: ExpoDevMenuItem = {
-  name: '📐 Toggle Screen Sizer',
-  callback: () => store.toggleIsEnabled(),
-};
 
 /**
  * NOTE: this will override any other custom items, not good!
  */
-export const registerExpoDevMenuItem = () => {
-  ExpoDevMenu.registerDevMenuItems([devMenuItem]).catch(console.warn);
+export const registerExpoDevMenuItem = async () => {
+  try {
+    const ExpoDevMenu = await import('expo-dev-menu');
+
+    await ExpoDevMenu.registerDevMenuItems([
+      {
+        name: '📐 Toggle Screen Sizer',
+        callback: () => store.toggleIsEnabled(),
+      },
+    ]);
+  } catch (error) {
+    console.log('Error with expo-dev-menu', error);
+  }
 };

--- a/src/integrations/expo-dev-menu.ts
+++ b/src/integrations/expo-dev-menu.ts
@@ -8,7 +8,6 @@ export const registerExpoDevMenuItem = async () => {
   try {
     ExpoDevMenu = await import('expo-dev-menu');
   } catch {
-    console.log('ScreenSizer: skipped registration of item in expo dev menu.');
     return;
   }
 

--- a/src/integrations/react-native-dev-menu.ts
+++ b/src/integrations/react-native-dev-menu.ts
@@ -1,0 +1,9 @@
+import { DevSettings } from 'react-native';
+
+import { store } from '../state';
+
+export const registerReactNativeDevMenuItem = () => {
+  DevSettings.addMenuItem('📐 Toggle Screen Sizer', () =>
+    store.toggleIsEnabled()
+  );
+};

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -1,14 +1,7 @@
 import { registerExpoDevMenuItem } from './integrations/expo-dev-menu';
 import { registerReactNativeDevMenuItem } from './integrations/react-native-dev-menu';
 
-type Config = {
-  registerExpoDevMenuItem?: boolean;
-  patchRNKeyboard?: boolean;
-};
-
-export const setup = (config?: Config) => {
-  if (config?.registerExpoDevMenuItem !== false) {
-    registerExpoDevMenuItem();
-  }
+export const setup = () => {
+  registerExpoDevMenuItem();
   registerReactNativeDevMenuItem();
 };

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -1,4 +1,5 @@
 import { registerExpoDevMenuItem } from './integrations/expo-dev-menu';
+import { registerReactNativeDevMenuItem } from './integrations/react-native-dev-menu';
 
 type Config = {
   registerExpoDevMenuItem?: boolean;
@@ -9,4 +10,5 @@ export const setup = (config?: Config) => {
   if (config?.registerExpoDevMenuItem !== false) {
     registerExpoDevMenuItem();
   }
+  registerReactNativeDevMenuItem();
 };


### PR DESCRIPTION
[Ticket: ETQDev, tester s’il est possible d’utiliser la lib sans expo](https://www.notion.so/m33/ETQDev-tester-s-il-est-possible-d-utiliser-la-lib-sans-expo-7fd0029b9b274565ba0832213f8c1ad0?pvs=4)

# Description

* Add a shortcut in the React Native Dev Menu to activate the feature
* Make the expo dependency optional
* Export a function to toggle the feature

# How was it tested

* Tested with expo go and expo with custom build

# Screenshots

<img src="https://github.com/bamlab/react-native-screen-sizer/assets/103410601/faa88fa9-4be4-4dbd-a695-046b411bb951" alt="" width="340" />
