### PR TITLE
Feat/warning if simulator too small

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,10 @@ Currently, other ways to read these dimensions (like the ones in the base `react
 
 If you use "static" dimensions, you app won't re-render properly when the device size changes. This applies to the "emulated size" from this package, but also to the real size (eg window resizing on iPad or M1 macs, or switching to landscape mode), so it's a good thing to do anyway!
 
+### Use a big screen as the "base device"
+
+We recommend using a big screen (eg `iPhone 14 Pro Max`) as the "base device" to develop on. If your base device is too small for the screen you're using, you'll get a warning in the console.
+
 ### Eslint config
 
 You can setup these eslint rules to enforce some of the guidelines above:
@@ -138,7 +142,6 @@ You can setup these eslint rules to enforce some of the guidelines above:
 
 - **Landscape mode** is not supported
 - On android, the **status bar** inset is applied as if the status bar is visible and translucent
-- If the "base device" is smaller than the "sized screen", behavior is undefined
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ If you use "static" dimensions, you app won't re-render properly when the device
 
 ### Use a big screen as the "base device"
 
-We recommend using a big screen (eg `iPhone 14 Pro Max`) as the "base device" to develop on. If your base device is too small for the screen you're using, you'll get a warning in the console.
+We recommend using a big screen (eg `iPhone 14 Pro Max`) as the "base device" to develop on. If your base device is too small for one of the screens you want to emulate, you'll get a warning in the console.
 
 ### Eslint config
 

--- a/src/Wrapper.tsx
+++ b/src/Wrapper.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react-native/no-inline-styles */
 import React, { PropsWithChildren, useEffect, useState } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { StyleSheet, View, useWindowDimensions } from 'react-native';
 import {
   SafeAreaFrameContext,
   SafeAreaInsetsContext,
@@ -43,6 +43,15 @@ const WrapperMemo = ({ children, devices }: WrapperMemoProps) => {
       (index) => (index + devicesList.length - 1) % devicesList.length
     );
   };
+
+  const { width: baseWidth, height: baseHeight } = useWindowDimensions();
+  const { width, height } = selectedDevice;
+
+  if (isEnabled && (baseWidth < width || baseHeight < height)) {
+    console.warn(
+      'ScreenSizer: The base device is too small for the device you want to emulate. Please choose a bigger base device or a smaller emulated device.'
+    );
+  }
 
   const realInsets = useSafeAreaInsets();
 

--- a/src/Wrapper.tsx
+++ b/src/Wrapper.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react-native/no-inline-styles */
 import React, { PropsWithChildren, useEffect, useState } from 'react';
-import { StyleSheet, View, useWindowDimensions } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 import {
   SafeAreaFrameContext,
   SafeAreaInsetsContext,
@@ -21,20 +21,20 @@ const WrapperMemo = ({ children, devices }: WrapperMemoProps) => {
   const { isEnabled } = useStore();
   const devicesList = devices || defaultDevices.all;
 
-  const { width: baseWidth, height: baseHeight } = useWindowDimensions();
+  const realFrame = useSafeAreaFrame();
 
   useEffect(() => {
     devicesList.forEach((device) => {
       if (
         isEnabled &&
-        (baseWidth < device?.width || baseHeight < device?.height)
+        (realFrame.width < device.width || realFrame.height < device.height)
       ) {
         console.warn(
-          `ScreenSizer: ${device?.name} is too large for the base device. Please choose a bigger base device or a smaller emulated device.`
+          `ScreenSizer: ${device.name} is too large for the base device. Please choose a bigger base device or a smaller emulated device.`
         );
       }
     });
-  }, [devicesList, baseWidth, baseHeight, isEnabled]);
+  }, [devicesList, isEnabled, realFrame]);
 
   const [selectedDeviceIndex, setSelectedDeviceIndex] = useState(0);
   const selectedDevice = devicesList[selectedDeviceIndex];
@@ -71,8 +71,6 @@ const WrapperMemo = ({ children, devices }: WrapperMemoProps) => {
         ...selectedDevice.insets,
       }
     : realInsets;
-
-  const realFrame = useSafeAreaFrame();
 
   const frame = isEnabled
     ? {

--- a/src/Wrapper.tsx
+++ b/src/Wrapper.tsx
@@ -20,6 +20,22 @@ type WrapperMemoProps = PropsWithChildren<{
 const WrapperMemo = ({ children, devices }: WrapperMemoProps) => {
   const { isEnabled } = useStore();
   const devicesList = devices || defaultDevices.all;
+
+  const { width: baseWidth, height: baseHeight } = useWindowDimensions();
+
+  useEffect(() => {
+    devicesList.forEach((device) => {
+      if (
+        isEnabled &&
+        (baseWidth < device?.width || baseHeight < device?.height)
+      ) {
+        console.warn(
+          `ScreenSizer: ${device?.name} is too large for the base device. Please choose a bigger base device or a smaller emulated device.`
+        );
+      }
+    });
+  }, [devicesList, baseWidth, baseHeight, isEnabled]);
+
   const [selectedDeviceIndex, setSelectedDeviceIndex] = useState(0);
   const selectedDevice = devicesList[selectedDeviceIndex];
 
@@ -43,15 +59,6 @@ const WrapperMemo = ({ children, devices }: WrapperMemoProps) => {
       (index) => (index + devicesList.length - 1) % devicesList.length
     );
   };
-
-  const { width: baseWidth, height: baseHeight } = useWindowDimensions();
-  const { width, height } = selectedDevice;
-
-  if (isEnabled && (baseWidth < width || baseHeight < height)) {
-    console.warn(
-      'ScreenSizer: The base device is too small for the device you want to emulate. Please choose a bigger base device or a smaller emulated device.'
-    );
-  }
 
   const realInsets = useSafeAreaInsets();
 


### PR DESCRIPTION
[Ticket: ETQDev, je suis alerté dans la console si la taille passé en prop est plus petite que la taille de mon simulateur](https://www.notion.so/m33/v0-1-ETQDev-je-suis-alert-dans-la-console-si-la-taille-pass-en-prop-est-plus-petite-que-la-taill-7b7ef2dbae72493fbfba775f34e40c4b?pvs=4)

# Description

* Add a console warning if baseDevice is too small for the chosen emulated device


<img src="https://github.com/bamlab/react-native-screen-sizer/assets/57703518/9f8b7585-0e29-4588-9702-76c424e5611b" alt="" width="340" />
