### PR TITLE
Use host device in config list

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ export const App = () => {
   return (
     <SafeAreaProvider>
       <ScreenSizer.Wrapper
+        // 👋 The list of devices that will be emulated. You can use some of our default devices, custom ones, or the keyword 'hostDevice' to reference your current host device.
         devices={[
           ScreenSizer.defaultDevices.iPhoneSE2016,
           {
@@ -55,6 +56,7 @@ export const App = () => {
             height: 400,
             insets: { top: 20, bottom: 20 },
           },
+          'hostDevice',
         ]}
       >
         {/* 👋 `ScreenSizer.Wrapper` must be inserted inside `SafeAreaProvider` but **around** any provider or component that uses safe area dimensions */}

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -9,7 +9,9 @@ ScreenSizer.setup();
 export default function App() {
   return (
     <SafeAreaProvider>
-      <ScreenSizer.Wrapper devices={ScreenSizer.defaultDevices.all}>
+      <ScreenSizer.Wrapper
+        devices={[ScreenSizer.defaultDevices.iPhoneSE2016, 'hostDevice']}
+      >
         <View style={styles.container}>
           <Text style={styles.title}>ScreenSizer Demo Application</Text>
           <Button

--- a/src/Wrapper.tsx
+++ b/src/Wrapper.tsx
@@ -14,14 +14,27 @@ import { useStore } from './state';
 import type { Device } from './types';
 
 type WrapperMemoProps = PropsWithChildren<{
-  devices?: Array<Device>;
+  devices?: Array<Device | 'hostDevice'>;
 }>;
 
 const WrapperMemo = ({ children, devices }: WrapperMemoProps) => {
   const { isEnabled } = useStore();
-  const devicesList = devices || defaultDevices.all;
-
   const realFrame = useSafeAreaFrame();
+  const realInsets = useSafeAreaInsets();
+
+  const devicesList =
+    devices?.map<Device>((device) => {
+      if (device === 'hostDevice') {
+        return {
+          name: 'Host Device',
+          width: realFrame.width,
+          height: realFrame.height,
+          insets: realInsets,
+        };
+      } else {
+        return device;
+      }
+    }) || defaultDevices.all;
 
   useEffect(() => {
     devicesList.forEach((device) => {
@@ -59,8 +72,6 @@ const WrapperMemo = ({ children, devices }: WrapperMemoProps) => {
       (index) => (index + devicesList.length - 1) % devicesList.length
     );
   };
-
-  const realInsets = useSafeAreaInsets();
 
   const insets = isEnabled
     ? {


### PR DESCRIPTION
[Ticket: [v0.1] ETQDev, je peux ajouter à ma liste de tailles le host Device](https://www.notion.so/m33/v0-1-ETQDev-je-peux-ajouter-ma-liste-de-tailles-le-host-Device-624be2fe010e4b2883d0bec823e6847e?pvs=4)

# Description

Use the host device as one of the available device in the list of devices in the wrapper prop. Can be used by specifying the `"hostDevice"` keyword as a device.

# Example

```jsx
<ScreenSizer.Wrapper
  devices={[ScreenSizer.defaultDevices.iPhoneSE2016, 'hostDevice']}
>
   {/* content */}
</ScreenSizer.Wrapper>
```