### PR TITLE
Feat/setup option activated by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ import { SafeAreaProvider } from 'react-native-safe-area-context';
 import * as ScreenSizer from 'react-native-screen-sizer';
 
 // 👋 Call this at the top-level of App.tsx. It will handle some things like register shortcuts in the dev menu.
-ScreenSizer.setup();
+ScreenSizer.setup({ activatedByDefault: false });
 
 export const App = () => {
   // ...

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -4,7 +4,7 @@ import { Button, StyleSheet, Text, View } from 'react-native';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import * as ScreenSizer from 'react-native-screen-sizer';
 
-ScreenSizer.setup();
+ScreenSizer.setup({ activatedByDefault: true });
 
 export default function App() {
   return (

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -1,7 +1,15 @@
 import { registerExpoDevMenuItem } from './integrations/expo-dev-menu';
 import { registerReactNativeDevMenuItem } from './integrations/react-native-dev-menu';
+import { store } from './state';
 
-export const setup = () => {
+type SetupConfig = {
+  activatedByDefault?: boolean;
+};
+
+export const setup = ({ activatedByDefault = false }: SetupConfig) => {
   registerExpoDevMenuItem();
   registerReactNativeDevMenuItem();
+  if (activatedByDefault) {
+    store.toggleIsEnabled();
+  }
 };


### PR DESCRIPTION
[Ticket : ETQDev, je peux activer/désactiver le sizer au démarrage de l’application](https://www.notion.so/m33/v0-1-ETQDev-je-peux-activer-d-sactiver-le-sizer-au-d-marrage-de-l-application-b95bd068df2c4c30b287cea9fed2840d?pvs=4)

# Description

Add setup option `activatedByDefault` (default: false)

```tsx
// 👋 Call this at the top-level of App.tsx. It will handle some things like register shortcuts in the dev menu.
ScreenSizer.setup({ activatedByDefault: false });
```
