### PR TITLE
Fix: Reduce build size

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "android",
     "ios",
     "cpp",
-    "assets",
+    "assets/images",
     "*.podspec",
     "!lib/typescript/example",
     "!ios/build",


### PR DESCRIPTION
# Description

* Current build size: 1.36 MB
* 1.24 MB is used just for the gif demo of the README

=> Remove assets only used in the README from the build. This reduces the build size by 1133 %.