### PR TITLE
fix: update lib name

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 
+import * as ScreenSizer from '@bam.tech/react-native-screen-sizer';
 import { Button, StyleSheet, Text, View } from 'react-native';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
-import * as ScreenSizer from 'react-native-screen-sizer';
 
 ScreenSizer.setup({ activatedByDefault: true });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": "./",
     "paths": {
-      "react-native-screen-sizer": ["./src/index"]
+      "@bam.tech/react-native-screen-sizer": ["./src/index"]
     },
     "allowUnreachableCode": false,
     "allowUnusedLabels": false,


### PR DESCRIPTION
The example app could fail to start, not finding the `react-native-screen-sizer` module.
This PR fixes this by harmonizing the module name import with the package name.