### PR TITLE
Fix: don't break layout after an iOS pageSheet dismissal by swipe

### DIFF
--- a/src/Wrapper.tsx
+++ b/src/Wrapper.tsx
@@ -123,10 +123,14 @@ const WrapperMemo = ({
       <SafeAreaFrameContext.Provider value={frame}>
         <SafeAreaInsetsContext.Provider value={insets}>
           <View
-            style={[
-              styles.fakeScreen,
-              { width: frame.width, height: frame.height },
-            ]}
+            style={
+              isEnabled
+                ? [
+                    styles.fakeScreen,
+                    { width: frame.width, height: frame.height },
+                  ]
+                : styles.identity
+            }
           >
             {children}
             {isEnabled && (

--- a/src/Wrapper.tsx
+++ b/src/Wrapper.tsx
@@ -119,9 +119,7 @@ const WrapperMemo = ({
    * ☢️ This tree must be the same whether isEnabled or not, otherwise children state is lost when toggling
    */
   return (
-    <View
-      style={isEnabled ? styles.wholeScreenEnabled : styles.wholeScreenDisabled}
-    >
+    <View style={isEnabled ? styles.wholeScreenEnabled : styles.identity}>
       <SafeAreaFrameContext.Provider value={frame}>
         <SafeAreaInsetsContext.Provider value={insets}>
           <View
@@ -193,7 +191,11 @@ const WrapperMemo = ({
 export const Wrapper = React.memo(WrapperMemo);
 
 const styles = StyleSheet.create({
-  wholeScreenDisabled: {
+  identity: {
+    /*
+     * View styles that are supposed to be "transparent": having this view should be like it being not present in terms of layout / visual impact
+     * This is useful because of the "having the same react tree whether enabled or not" requirement
+     */
     width: '100%',
     height: '100%',
   },
@@ -211,7 +213,6 @@ const styles = StyleSheet.create({
   fakeScreen: {
     backgroundColor: 'white',
   },
-
   deviceInfo: {
     backgroundColor: '#FFFFFF99',
     position: 'absolute',


### PR DESCRIPTION
When opening an iOS UIViewController in `pageSheet` mode, the screen(s) behind it gets resized.

→ In a typical RN app, this includes the main `UIViewController`
→ The top-level `SafeAreaProvider` sees this resizing
→ The values returned by `useSafeAreaFrame` change
→ rerenders of screen-sizer occur

Problem : when dismissing the `pageSheet` by swiping, there are many of these resizing events and at some point something breaks, leaving the "screen behind" in a broken state (with white zones on the right and at the bottom) when the dismissal is over

There's probably a fix to be made in `useSafeAreaFrame` too, but the issue is not visible without screen-sizer, and we should try to ensure it behaves as if it's not present when disabled
